### PR TITLE
Use axios instance for auth context

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:3000

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { supabase } from '@/services/supabaseClient';
-import axios from 'axios';
+import api from '@/services/api';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Session, User, AuthResponse } from '@supabase/supabase-js';
 
@@ -101,7 +101,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const resetPassword = async (email: string) => {
     // Вызываем наш бэкенд
-    const res = await axios.post('/auth/reset-password', { email });
+    const res = await api.post('/auth/reset-password', { email });
     return res.data;
   };
 
@@ -126,7 +126,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         return;
       }
       const { access_token: token } = session;
-      const res = await axios.get('/auth/me', {
+      const res = await api.get('/auth/me', {
         headers: { Authorization: `Bearer ${token}` },
       });
       setUser(res.data);


### PR DESCRIPTION
## Summary
- use preconfigured Axios instance in `AuthContext`
- add `.env` for API base URL

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687860e5b14c8331b207ba3361c71d2f